### PR TITLE
Build-time optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags =  ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ rayon = "1.3"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[profile.release]
+opt-level = 3
+lto = "fat"


### PR DESCRIPTION
This PR enables the following on all benches:

 * Link-time optimization
 * Compiling for the native CPU architecture.

This should provide a more level comparison for what the upper bound on perf for each of the ECS implementations looks like.