### PR TITLE
Add Status section to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,12 @@ A suite of benchmarks designed to test and compare Rust ECS library performance 
 
 The full benchmark report is available [here](https://rust-gamedev.github.io/ecs_bench_suite/target/criterion/report/index.html).
 
+## Status
+
+The project is now archived - see discussion [here](https://github.com/rust-gamedev/wg/issues/130); summary:
+
+> [The project] arguably went quite well even though it’s not that actively updated; I like to think we collectively realized that speed is only one aspect of an ECS, and a rather small one at that once a baseline of performance has been established.
+
 ## The Benchmarks
 
 ### Simple Insert


### PR DESCRIPTION
Add Status (archival description) section to README.

Closes https://github.com/rust-gamedev/wg/issues/130.